### PR TITLE
Use the parent name so we can keep the old sessions

### DIFF
--- a/Laravel/SessionGuard.php
+++ b/Laravel/SessionGuard.php
@@ -56,7 +56,27 @@ class SessionGuard extends \Illuminate\Auth\SessionGuard
 
         return parent::setRequest($request);
     }
+    
+    /**
+     * Get a unique identifier for the auth session value.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'login_'.$this->name.'_'.sha1(parent::class);
+    }
 
+    /**
+     * Get the name of the cookie used to store the "recaller".
+     *
+     * @return string
+     */
+    public function getRecallerName()
+    {
+        return 'remember_'.$this->name.'_'.sha1(parent::class);
+    }
+    
     /**
      * Reset the state of current class instance.
      *
@@ -69,5 +89,6 @@ class SessionGuard extends \Illuminate\Auth\SessionGuard
         $this->viaRemember = false;
         $this->loggedOut = false;
         $this->tokenRetrievalAttempted = false;
+        $this->recallAttempted  = false;
     }
 }


### PR DESCRIPTION
I was migrating a Laravel 5.5 project to use php-pm.

One big issue for us, was that all our users would get logged-out in this migration.

With this patch, we use the parent class name so we can keep the old sessions intact